### PR TITLE
Cleanup options and JS

### DIFF
--- a/eyas.js
+++ b/eyas.js
@@ -11,7 +11,9 @@
     return "[ch-error: missing label "+label+" ]";
   }
 
-  function getText(preview, token, label, lang, element) {
+  function getText(label, element) {
+    var staging = options.advancedOptions.environment === 'staging';
+
     var xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function() {
       if (xhttp.readyState == 4 && xhttp.status == 200) {
@@ -22,9 +24,9 @@
     }
 
     var url = "//app.copyhawk.co/api/";
-    if (preview)
+    if (staging)
       url += 'p/staging.';
-    url += token + "/" + label + "?lang=" + lang + "&cache=" + Math.random().toString(36);
+    url += options.token + "/" + label + "?lang=" + options.advancedOptions.defaultLanguage + "&cache=" + Math.random().toString(36);
 
     xhttp.open("GET", url, true);
     xhttp.setRequestHeader("Content-Type", "text/plain");
@@ -34,11 +36,9 @@
   function loadTags() {
     var tags = document.querySelectorAll('c-hawk');
 
-    var preview = options.advancedOptions.environment === 'staging';
-
     if (tags) {
       for (var i=tags.length; i--;){
-        getText(preview, options.token, tags[i].dataset.label, options.advancedOptions.defaultLanguage, tags[i]);
+        getText(tags[i].dataset.label, tags[i]);
       }
     }
   }
@@ -62,5 +62,13 @@
   }
 
   document.addEventListener('DOMContentLoaded', render);
+
+  if (document.registerElement){
+    var cHawkProto = Object.create(HTMLElement.prototype);
+    cHawkProto.createdCallback = function() {
+      getText(this.dataset.label, this);
+    }
+    document.registerElement("c-hawk", {prototype: cHawkProto});
+  }
 
 })();

--- a/eyas.js
+++ b/eyas.js
@@ -1,77 +1,66 @@
-var copyHawkMaster;
-
 (function(){
 
   var options = INSTALL_OPTIONS;
 
-  if (!options.token && !options.defaultLanguage) {
+  if (!options.token) {
     return;
   }
 
-  var initTag = document.createElement('c-hawk-init');
-  initTag.setAttribute('data-site-token',options.token);
-  initTag.setAttribute('data-default-language',options.defaultLanguage);
-  initTag.setAttribute('data-supported-languages',options.supportedLanguages);
-  initTag.setAttribute('data-environment',options.environment);
-  document.body.appendChild(initTag);
+  function getDefault(label) {
+    // Fail fast simple debug
+    return "[ch-error: missing label "+label+" ]";
+  }
 
-  copyHawkMaster = {
-    init: function() {
-      var lookup = document.getElementsByTagName('c-hawk-init')[0].dataset;
-      this.siteToken = lookup.siteToken;
-      this.language = lookup.defaultLanguage;
-      this.supportedLanguages = lookup.supportedLanguages;
-      if (lookup.environment == "preview") {
-        this.preview = true;
+  function getText(preview, token, label, lang, element) {
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+      if (xhttp.readyState == 4 && xhttp.status == 200) {
+        element.innerHTML = xhttp.responseText;
+      } else if (xhttp.readyState == 4 && xhttp.status == 404) {
+        element.innerHTML = getDefault(label);
       }
-      this.noCache = new Date().getTime();
+    }
+
+    var url = "//app.copyhawk.co/api/";
+    if (preview)
+      url += 'p/staging.';
+    url += token + "/" + label + "?lang=" + lang + "&cache=" + Math.random().toString(36);
+
+    xhttp.open("GET", url, true);
+    xhttp.setRequestHeader("Content-Type", "text/plain");
+    xhttp.send();
+  }
+
+  function loadTags() {
+    var tags = document.querySelectorAll('c-hawk');
+
+    var preview = options.advancedOptions.environment === 'staging';
+
+    if (tags) {
+      for (var i=tags.length; i--;){
+        getText(preview, options.token, tags[i].dataset.label, options.advancedOptions.defaultLanguage, tags[i]);
+      }
     }
   }
-  copyHawkMaster.init();
 
+  var regionEls = [];
+  function writeTags() {
+    for (var i=options.regions.length; i--;){
+      var region = options.regions[i];
+
+      regionEls[i] = Eager.createElement(region.location, regionEls[i]);
+
+      var child = document.createElement('c-hawk');
+      child.dataset.label = region.label;
+      regionEls[i].appendChild(child);
+    }
+  }
+
+  function render() {
+    writeTags();
+    loadTags();
+  }
+
+  document.addEventListener('DOMContentLoaded', render);
 
 })();
-
-function getDefault(label) {
-  // Fail fast simple debug
-  return "[ch-error: missing label "+label+" ]";
-}
-
-function getPreviewText(token, label, lang, cacheKey, element) {
-  var xhttp = new XMLHttpRequest();
-  xhttp.onreadystatechange = function() {
-    if (xhttp.readyState == 4 && xhttp.status == 200) {
-      element.innerHTML = xhttp.responseText;
-    } else if (xhttp.readyState == 4 && xhttp.status == 404) {
-      element.innerHTML = getDefault(label);
-    }
-  }
-  xhttp.open("GET", "//app.copyhawk.co/api/p/staging." + token + "/" + label + "?lang="+lang+"&cache="+cacheKey, true);
-  xhttp.setRequestHeader("Content-Type", "text/plain");
-  xhttp.send();
-}
-
-function getLiveText(token, label, lang, cacheKey, element) {
-  var xhttp = new XMLHttpRequest();
-  xhttp.onreadystatechange = function() {
-    if (xhttp.readyState == 4 && xhttp.status == 200) {
-      element.innerHTML = xhttp.responseText;
-    } else if (xhttp.readyState == 4 && xhttp.status == 404) {
-      element.innerHTML = getDefault(label);
-    }
-  }
-  xhttp.open("GET", "//app.copyhawk.co/api/" + token + "/" + label + "?lang="+lang+"&cache="+cacheKey, true);
-  xhttp.setRequestHeader("Content-Type", "text/plain");
-  xhttp.send();
-}
-
-// Init script tags
-var cHawkProto = Object.create(HTMLElement.prototype);
-cHawkProto.createdCallback = function () {
-  if (copyHawkMaster.preview) {
-    getPreviewText(copyHawkMaster.siteToken, this.dataset.label, copyHawkMaster.language, copyHawkMaster.noCache, this);
-  } else {
-    getLiveText(copyHawkMaster.siteToken, this.dataset.label, copyHawkMaster.language, copyHawkMaster.noCache, this);
-  }
-};
-var cHawk = document.registerElement("c-hawk", {prototype: cHawkProto});

--- a/install.json
+++ b/install.json
@@ -1,10 +1,10 @@
 {
   "resources": {
-    "body": [
+    "head": [
       {
         "type": "script",
         "src": "./polyfill.min.js",
-        "if": "options.backwardCompatible"
+        "if": "options.advancedOptions.backwardCompatible"
       },
       {
         "type": "script",
@@ -17,27 +17,85 @@
       "token": {
         "title": "Site Token",
         "description": "Enter the token provided to you by Copyhawk",
-        "type": "string"
+        "type": "string",
+        "placeholder": "56cc6ec24ddf06d61e9d5ba5",
+        "order": 1
       },
-      "defaultLanguage": {
-        "title": "Default Language",
-        "description": "Enter the default language for your site",
-        "type": "string"
+      "regions": {
+        "title": "Regions",
+        "description": "Text on the page to be inserted or replaced using Copyhawk",
+        "type": "array",
+        "order": 2,
+        "items": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "title": "Location",
+              "type": "object",
+              "format": "element",
+              "description": "Where on the page you would like this Copyhawk text to be inserted",
+              "order": 1
+            },
+            "label": {
+              "title": "Copyhawk Label",
+              "type": "string",
+              "description": "The field label provided by Copyhawk on the <a href='https://app.copyhawk.co/#/home' target='_blank'>Copy Configuration Page</a>.",
+              "order": 2
+            }
+          }
+        }
       },
-      "supportedLanguages": {
-        "title": "Supported Languages",
-        "description": "Enter the languages that your site supports",
-        "type": "string"
+      "showAdvancedOptions": {
+        "title": "Show Advanced Options",
+        "type": "boolean",
+        "order": 3
       },
-      "environment": {
-        "title": "Environment",
-        "description": "Staging or Production - anything not matching staging will be considered production",
-        "type": "string"
-      },
-      "backwardCompatible": {
-        "title": "Polyfill Support",
-        "description": "Enter true if you need to add polyfill support for older browsers",
-        "type": "boolean"
+      "advancedOptions": {
+        "title": "Advanced Options",
+        "type": "object",
+        "showIf": "showAdvancedOptions",
+        "order": 4,
+        "properties": {
+          "defaultLanguage": {
+            "title": "Default Language",
+            "description": "Enter the default language for your site",
+            "type": "string",
+            "default": "en",
+            "order": 1
+          },
+          "supportedLanguages": {
+            "title": "Supported Languages",
+            "description": "Enter the languages that your site supports",
+            "type": "array",
+            "items": {
+              "title": "Language Code",
+              "type": "string"
+            },
+            "default": ["en"],
+            "order": 2
+          },
+          "environment": {
+            "title": "Environment",
+            "type": "string",
+            "enum": [
+              "staging",
+              "production"
+            ],
+            "enumNames": {
+              "staging": "Staging",
+              "production": "Production"
+            },
+            "default": "production",
+            "order": 3
+          },
+          "backwardCompatible": {
+            "title": "Polyfill Support",
+            "description": "Uncheck for a slight performance boost if you don’t need your site to support older browsers (like Internet Explorer)",
+            "type": "boolean",
+            "default": true,
+            "order": 4
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
You can view a preview of these changes here: [Preview](https://eager.io/developer/app-tester?version=zdts3okb4i-1458599651209)

Here is a partial summary of the changes:
- Make it possible to specify regions to be inserted using Eager
- Prevent leaking of global variables
- Remove unnecessary HTML elements and objects which are only used in this file
- Merge both XHR functions into a single function with an extra option
- Add Advanced Options section to hide technical options from less technical users
- Use an enumeration for the environment option
- Make the polyfill default, as many users won't understand when it should be checked

I left the support in for the web component method of installing, but it's possible it would make more sense to only support adding regions with Eager.  It makes sense to me that users who are installing with Eager will also want to specify their regions that way.

You'll notice that there is a momentary flash before the content regions are inserted.  I would suggest using Mutation Observers to fix that, please let me know if you'd like some examples.
